### PR TITLE
fix(sprint1-seabattle): fix project name in comment

### DIFF
--- a/sprint1/problems/seabattle/precode/CMakeLists.txt
+++ b/sprint1/problems/seabattle/precode/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-# Проект называется Hello и написан на C++
+# Проект называется Seabattle и написан на C++
 project(Seabattle CXX)
 # Исходый код будет компилироваться с поддержкой стандарта С++ 20
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
The SeaBattle project name in the comment in CMakeLists.txt has been corrected to match the name set in the “project” command.